### PR TITLE
Off-by-one problem (maximum non-data Twrite message size is 23, not 24)

### DIFF
--- a/9p.go
+++ b/9p.go
@@ -46,7 +46,7 @@ const (
 
 const (
 	MSIZE   = 8192 + IOHDRSZ // default message size (8192+IOHdrSz)
-	IOHDRSZ = 24             // the non-data size of the Twrite messages
+	IOHDRSZ = 23             // the non-data size of the Twrite messages
 	PORT    = 564            // default port for 9P file servers
 )
 


### PR DESCRIPTION
I've been debugging my 9P implementation [djs55/ocaml-9p] against go9p and noticed a difference in the write message handling. If I'm reading the spec correctly then I think there's an off-by-one in go9p. What do you think?

The manpage describes Twrite as:

size[4] Twrite tag[2] fid[4] offset[8] count[4] data[count]

if count = 0, the message size is 4 + 1 + 2 + 4 + 8 + 4 = 23

This manifests as a bug if a client agrees a maximum message size
with a server, and then computes the maximum value for `count`
by subtracting 23 i.e. the biggest possible write message. If the
server then checks whether the request is too big by subtracting
24, it will return an error.

Signed-off-by: David Scott <dave.scott@unikernel.com>